### PR TITLE
Do not checkout more than once when the event is pull request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,24 +30,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: 'Checkout ${{ inputs.main-branch }}'
+    - name: 'Checkout'
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.main-branch }}
         fetch-depth: 0
     - name: 'Rebase ${{ inputs.staging-branch }} onto ${{ inputs.main-branch }}'
+      if: github.event_name != 'pull_request'
       shell: bash
       run: |
-        # Leave the staging branch unchanged if this is a PR.  This is not a
-        # GitHub Actions-level "if" because we want this job to return success
-        # (so that subsequent jobs run).
-        if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-          exit 0
-        fi
-
         # Rebase the staging branch on the default branch.  Create the staging
         # branch if it doesn't exist.
-        git checkout -b ${{ inputs.staging-branch }}
+        git checkout -b ${{ inputs.staging-branch }} ${{ inputs.main-branch }}
         if [[ ! `git fetch origin ${{ inputs.staging-branch }}` ]]; then
           git reset --hard origin/${{ inputs.staging-branch }}
           git config user.name ${{ inputs.user }}
@@ -56,12 +49,3 @@ runs:
         fi
 
         git push --force origin ${{ inputs.staging-branch }}
-
-    - name: 'Switch to work branch'
-      shell: bash
-      run: |
-        if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-          git checkout ${{ github.head_ref }}
-        else
-          git checkout ${{ inputs.staging-branch }}
-        fi


### PR DESCRIPTION
Fix the script doesn't work for forked repo. Only tested on a PR with a forked repo (chipsalliance/chisel#3662), not tested with a non-fork PR and with a non-pull-request event.

### Changes Explanations

- Always checkout the event branch at the beginning.

- Rebase only when `event != 'pull-request'`, `git checkout` to `inputs.staging-branch` with an additional argument `<start-point>`, it's almost equal to `git checkout <start-point> && git checkout -b <new-branch>`

- GitHub Action-level `if` is fine here, because it only skip the current step if the condition is not satisfied, not fails the whole job.

- Since we checked out the event branch at the beginning, and if `event != 'pull-request'` we also checked out the `staging-branch` at the rebase step, the last checkout is not necessary I guess?